### PR TITLE
Add alias icon that IoTC is using for device associate

### DIFF
--- a/src/_icons.scss
+++ b/src/_icons.scss
@@ -1485,4 +1485,5 @@
     .icon-alias-column-options { @extend .icon-exploitProtectionSettings };
     .icon-alias-configure { @extend .icon-settings };
     .icon-alias-migrate-device { @extend .icon-importAllMirrored };
+    .icon-alias-associate-device { @extend .icon-previewLink };
 }


### PR DESCRIPTION
This was lost during the conversion to open source. No image is currently being shown for associate button.