### PR TITLE
Update constants to align with office fabric fluent update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,24 @@
 # CHANGELOG
 
+## v7.1.1
+### Changed
+- Updated `$layout-nav-item-height` to align with office fabric's fluent command bar update.
+
 ## v7.1.0
-## Changed
+### Changed
 - RTL is now handled by using the `dir` attribute in the root html element.
 
 ## v7.0.4
-## Fixed
+### Fixed
 - `--color-bg-loading-panel` color in dark mode to be a darker grey to decrease its contrast
 
 ## v7.0.3
-## Fixed
+### Fixed
 - Reverted container color change made in v7.0.2
 - Added appropriate dashboard background color.
 
 ## v7.0.2
-## Changed
+### Changed
 - Container background color in light color to be light gray instead of white
 
 ## v7.0.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
   "description": "Azure IoT common styles library for CSS, Colors and Themes",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "license": "MIT",
   "engines": {
     "node": "^8.0.0"

--- a/src/_constants.scss
+++ b/src/_constants.scss
@@ -42,7 +42,8 @@ $dropdown-max-height: 50*$grid-size;
 
 // Layout
 
-$layout-nav-item-height: 2.5rem;
+$layout-nav-item-height: 2.75rem;
+$layout-header-xlarge-height: $layout-nav-item-height * 4;
 $layout-header-large-height: $layout-nav-item-height * 3;
 $layout-header-medium-height: $layout-nav-item-height * 2;
 $layout-header-small-height: $layout-nav-item-height;


### PR DESCRIPTION
Office fabric updated their command bar height to 44px (2.75rem), we need to update our `$layout-nav-item-height` to match that and have all our site's layout to update in the same way.

Here is the reference for that height change https://github.com/OfficeDev/office-ui-fabric-react/commit/cf893d1feebb868ae07e96e7c476b361b953fc5a#diff-67b0ecc6b3d15d4195d7b2a36b12f8a2R3