### PR TITLE
Fix contrast color on toggle circle for dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v7.1.2
+### Fixed
+- Added sufficient contrast to toggle on dark theme.
+
 ## v7.1.1
 ### Changed
 - Updated `$layout-nav-item-height` to align with office fabric's fluent command bar update.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
   "description": "Azure IoT common styles library for CSS, Colors and Themes",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "license": "MIT",
   "engines": {
     "node": "^8.0.0"

--- a/src/dark/_color.fluent.scss
+++ b/src/dark/_color.fluent.scss
@@ -127,9 +127,9 @@
     --color-border-toggle-on-disabled: var(--color-text-30);
     --color-border-toggle-off-disabled: var(--color-text-30);
     --color-circle-toggle-on-rest: var(--color-white);
-    --color-circle-toggle-off-rest: var(--color-text-10);
+    --color-circle-toggle-off-rest: var(--color-grey-40);
     --color-circle-toggle-on-hover: var(--color-white); //Size circle reduce to have
-    --color-circle-toggle-off-hover: var(--color-black);
+    --color-circle-toggle-off-hover: var(--color-grey-20);
     --color-circle-toggle-on-focus: var(--color-white);
     --color-circle-toggle-off-focus: var(--color-black);
     --color-circle-toggle-on-disabled: var(--color-text-20);


### PR DESCRIPTION
Circle color for the toggle component in dark theme doesn't have enough contrast to look fine. Updating the colors so it looks better.