### PR TITLE
Change --color-text-active in dark mode to color-white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v7.1.3
+### Changed
+- Changed `--color-text-active` in `dark/_color.fluent.scss` to `--color-white`
+
 ## v7.1.2
 ### Fixed
 - Added sufficient contrast to toggle on dark theme.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
   "description": "Azure IoT common styles library for CSS, Colors and Themes",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "license": "MIT",
   "engines": {
     "node": "^8.0.0"

--- a/src/dark/_color.fluent.scss
+++ b/src/dark/_color.fluent.scss
@@ -160,7 +160,7 @@
     --color-text-disabled: var(--color-text-30);
     --color-text-masthead: var(--color-white);
     --color-text-navbar: var(--color-white);
-    --color-text-active: var(--color-text-50);
+    --color-text-active: var(--color-white);
     --color-text-action-trigger: var(--color-text-rest);
 
     // Buttons


### PR DESCRIPTION
`--color-text-active` for the dark color palette was set to `--color-text-50` which doesn't exist. 
I've changed it to `color-white` and have confirmed that the two controls that use this color (`Calendar` and `TimeInput`) are unaffected.