### PR TITLE
Update focus outline color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v8.1.3
+### Changed
+- Update `focus-visible` outline color from `foreground-default` to `foreground-inactive`
+
 ## v8.1.2
 ### Changed
 - Update `focus-visible` class to align to FluentUI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
   "description": "Azure IoT common styles library for CSS, Colors and Themes",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/_normalize.scss
+++ b/src/_normalize.scss
@@ -209,7 +209,7 @@
 
   .focus-visible {
     &:focus {
-      outline: 1px solid var(--color-foreground-default);
+      outline: 1px solid var(--color-foreground-inactive);
       outline-offset: -1px;
     }
     
@@ -218,7 +218,7 @@
     }
     
     &:focus-visible {
-      outline: 1px solid var(--color-foreground-default);
+      outline: 1px solid var(--color-foreground-inactive);
       outline-offset: -1px;
     }
   }


### PR DESCRIPTION
After a conversation with design it seems like the correct color to use for the focus outline is `foreground-inactive`... updating it in the library