### PR TITLE
Add new sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v8.1.5
+### Changed
+- Added new `$size-115` and `$max-size-90` that accomodate for needs in page templates.
+
 ## v8.1.4
 ### Changed
 - Remove unused semi-transparent colors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
   "description": "Azure IoT common styles library for CSS, Colors and Themes",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/_constants.scss
+++ b/src/_constants.scss
@@ -24,6 +24,7 @@ $size-80: 8rem;
 $size-90: 10rem;
 $size-100: 12.5rem;
 $size-110: 16rem;
+$size-115: 18.75rem;
 $size-120: 21.25rem;
 $size-130: 40.25rem;
 $size-140: 58.75rem;
@@ -38,6 +39,7 @@ $max-size-50: 40rem;
 $max-size-60: 50rem;
 $max-size-70: 60rem;
 $max-size-80: 70rem;
+$max-size-90: 87.5rem;
 
 // Z Index
 


### PR DESCRIPTION
With the development of the page templates we needed a size for the secondary navigation panel and a max size for the content section. This two new sizes added match the fluent UI sizes for those two uses cases.