### PR TITLE
Fix height issue on webkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v8.1.7
 ### Changed
+- Fixed app height on webkit based browsers to take all available space instead of 100vh
+
+## v8.1.7
+### Changed
 - Updated `$max-size-60` to 46.25rem
 
 ## v8.1.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
-  "version": "8.1.7",
+  "version": "8.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/azure-iot-ux-fluent-css",
   "description": "Azure IoT common styles library for CSS, Colors and Themes",
-  "version": "8.1.7",
+  "version": "8.1.8",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/_normalize.scss
+++ b/src/_normalize.scss
@@ -15,7 +15,15 @@
 }
 
 :global {
+  :root {
+    // Fix webkit mobile bug with handling 100vh hiding it over the sticky browser footer
+    height: -webkit-fill-available;
+  }
+
   body {
+    height: 100vh;
+    height: -webkit-fill-available;
+
     margin: 0;
     padding: 0;
 
@@ -26,7 +34,8 @@
   }
 
   #root {
-    height: 100vh;
+    height: 100%;
+    height: -webkit-fill-available;
     
     // Set positioning to relative so that everything flows from shell
     position: relative;


### PR DESCRIPTION
It seems like there's a mess in mobile browsers around what `100vh` means (https://nicolas-hoizey.com/articles/2015/02/18/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers/).

Today on iphone mobile usage, our page grows to be hidden by safari's footer bar, which makes it really bad to interact. I've tested this in all mayor desktop browsers as well as safari on an iphone and it works as expected.